### PR TITLE
fix(git): allow passwords in git credentials

### DIFF
--- a/patches/git/credential.c.patch
+++ b/patches/git/credential.c.patch
@@ -1,0 +1,16 @@
+diff --git a/credential.c b/credential.c
+index 18098bd..f6212d4 100644
+--- a/credential.c
++++ b/credential.c
+@@ -71,6 +71,11 @@ static int credential_config_callback(const char *var, const char *value,
+ 			free(c->username);
+ 			c->username = xstrdup(value);
+ 		}
++	} else if (!strcmp(key, "password")) {
++		if (!c->password) {
++			free(c->password);
++			c->password = xstrdup(value);
++		}
+ 	}
+ 	else if (!strcmp(key, "usehttppath"))
+ 		c->use_http_path = git_config_bool(var, value);


### PR DESCRIPTION
This PR adds a git patch to allow setting passwords through `credential.password` instead of `credential.helper`. The usage can the be simplified to:

```
git config --global credential.password <password>
```

This is done because there are just so many issues with the `credential.helper` utility. It forks a child subprocess to execute the helper only to extract data (here, password) from the stdout stream of the child process. Child subprocesses are hard to debug in an Android 10 selinux read-write protected environment because a process can't invoke commands/scripts on its own. Using the system linker didn't seem to work too.

Attempts to write a helper which exposes a hardcoded SharedPreference string is anyway equivalent to letting set password manually. Thus this approach.