### PR TITLE
chore(ruby/gems): update deps

### DIFF
--- a/patches/ruby/bundled_gems.patch
+++ b/patches/ruby/bundled_gems.patch
@@ -9,15 +9,15 @@ index ae0a1ac..96cc6a1 100644
 +
 +activesupport 7.1.3.4 https://github.com/rails/rails/tree/v7.1.3.4/activesupport
 +addressable 2.8.7 https://github.com/sporkmonger/addressable
-+base64 0.2.0 https://github.com/ruby/base64
-+bigdecimal 3.1.8 https://github.com/ruby/bigdecimal
++base64 0.3.0 https://github.com/ruby/base64
++bigdecimal 3.2.2 https://github.com/ruby/bigdecimal
 +coffee-script 2.4.1 http://github.com/josh/ruby-coffee-script
 +coffee-script-source 1.12.2 http://coffeescript.org
 +colorator 1.1.0 https://github.com/octopress/colorator
 +commonmarker 0.23.10 https://github.com/gjtorikian/commonmarker
-+concurrent-ruby 1.3.4 https://github.com/ruby-concurrency/concurrent-ruby
-+connection_pool 2.4.1 https://github.com/mperham/connection_pool
-+csv 3.3.0 https://github.com/ruby/csv
++concurrent-ruby 1.3.5 https://github.com/ruby-concurrency/concurrent-ruby
++connection_pool 2.5.3 https://github.com/mperham/connection_pool
++csv 3.3.5 https://github.com/ruby/csv
 +dnsruby 1.72.1 https://github.com/alexdalitz/dnsruby
 +drb 2.2.1 https://github.com/ruby/drb
 +em-websocket 0.5.3 http://github.com/igrigorik/em-websocket
@@ -30,10 +30,10 @@ index ae0a1ac..96cc6a1 100644
 +forwardable-extended 2.6.0 http://github.com/envygeeks/forwardable-extended
 +gemoji 4.1.0 https://github.com/github/gemoji
 +github-pages-health-check 1.18.2 https://github.com/github/github-pages-health-check
-+google-protobuf 4.27.3 https://github.com/protocolbuffers/protobuf/tree/v4.27.3/ruby
++google-protobuf 4.31.1 https://github.com/protocolbuffers/protobuf/tree/v4.27.3/ruby
 +html-pipeline 2.14.3 https://github.com/jch/html-pipeline
 +http_parser.rb 0.8.0 https://github.com/tmm1/http_parser.rb
-+i18n 1.14.5 https://github.com/ruby-i18n/i18n
++i18n 1.14.7 https://github.com/ruby-i18n/i18n
 +jekyll 3.10.0 https://github.com/jekyll/jekyll
 +jekyll-avatar 0.8.0 https://github.com/jekyll/jekyll-avatar
 +jekyll-coffeescript 1.2.2 https://github.com/jekyll/jekyll-coffeescript
@@ -85,7 +85,7 @@ index ae0a1ac..96cc6a1 100644
 +pathutil 0.16.2 http://github.com/envygeeks/pathutil
 +public_suffix 5.1.1 https://github.com/weppos/publicsuffix-ruby/tree/v5.1.1
 +racc 1.8.0 https://github.com/ruby/racc
-+rake 13.2.1 https://github.com/ruby/rake/tree/v13.2.1
++rake 13.3.0 https://github.com/ruby/rake/tree/v13.2.1
 +rb-fsevent 0.11.2 https://github.com/thibaudgg/rb-fsevent
 +rb-inotify 0.11.1 https://github.com/guard/rb-inotify
 +rexml 3.3.5 https://github.com/ruby/rexml
@@ -104,5 +104,5 @@ index ae0a1ac..96cc6a1 100644
 +unf_ext 0.0.8.2 https://github.com/knu/ruby-unf_ext
 +unicode-display_width 1.8.0 https://github.com/janlelis/unicode-display_width
 +uri 0.13.0 https://github.com/ruby/uri
-+webrick 1.8.1 https://github.com/ruby/webrick
++webrick 1.9.1 https://github.com/ruby/webrick
 +github-pages 232 https://github.com/github/pages-gem

--- a/patches/ruby/bundled_gems.patch
+++ b/patches/ruby/bundled_gems.patch
@@ -29,6 +29,7 @@ index ae0a1ac..96cc6a1 100644
 +ffi 1.17.2 https://github.com/ffi/ffi/
 +forwardable-extended 2.6.0 http://github.com/envygeeks/forwardable-extended
 +gemoji 4.1.0 https://github.com/github/gemoji
++github-pages 232 https://github.com/github/pages-gem
 +github-pages-health-check 1.18.2 https://github.com/github/github-pages-health-check
 +google-protobuf 4.31.1 https://github.com/protocolbuffers/protobuf/tree/v4.27.3/ruby
 +html-pipeline 2.14.3 https://github.com/jch/html-pipeline
@@ -75,7 +76,7 @@ index ae0a1ac..96cc6a1 100644
 +kramdown-parser-gfm 1.1.0 https://github.com/kramdown/parser-gfm
 +liquid 4.0.4 http://www.liquidmarkup.org
 +listen 3.9.0 https://github.com/guard/listen/tree/v3.9.0
-+mercenary 0.3.6 https://github.com/jekyll/mercenary
++mercenary 0.4.0 https://github.com/jekyll/mercenary
 +mini_portile2 2.8.7 https://github.com/flavorjones/mini_portile
 +minima 2.5.1 https://github.com/jekyll/minima
 +mutex_m 0.2.0 https://github.com/ruby/mutex_m
@@ -83,12 +84,12 @@ index ae0a1ac..96cc6a1 100644
 +nokogiri 1.16.7 https://github.com/sparklemotion/nokogiri
 +octokit 4.25.1 https://github.com/octokit/octokit.rb
 +pathutil 0.16.2 http://github.com/envygeeks/pathutil
-+public_suffix 5.1.1 https://github.com/weppos/publicsuffix-ruby/tree/v5.1.1
++public_suffix 6.0.2 https://github.com/weppos/publicsuffix-ruby/tree/v5.1.1
 +racc 1.8.0 https://github.com/ruby/racc
 +rake 13.3.0 https://github.com/ruby/rake/tree/v13.2.1
 +rb-fsevent 0.11.2 https://github.com/thibaudgg/rb-fsevent
 +rb-inotify 0.11.1 https://github.com/guard/rb-inotify
-+rexml 3.3.5 https://github.com/ruby/rexml
++rexml 3.4.1 https://github.com/ruby/rexml
 +rouge 3.30.0 https://github.com/rouge-ruby/rouge
 +rubyzip 2.3.2 https://github.com/rubyzip/rubyzip/tree/v2.3.2
 +safe_yaml 1.0.5 https://github.com/dtao/safe_yaml
@@ -97,12 +98,11 @@ index ae0a1ac..96cc6a1 100644
 +sawyer 0.9.2 https://github.com/lostisland/sawyer
 +simpleidn 0.2.3 https://github.com/mmriis/simpleidn
 +strscan 3.1.5 https://github.com/ruby/strscan
-+terminal-table 1.8.0 https://github.com/tj/terminal-table
++terminal-table 3.0.2 https://github.com/tj/terminal-table
 +typhoeus 1.4.1 https://github.com/typhoeus/typhoeus
 +tzinfo 2.0.6 https://github.com/tzinfo/tzinfo/tree/v2.0.6
 +unf 0.1.4 https://github.com/knu/ruby-unf
 +unf_ext 0.0.8.2 https://github.com/knu/ruby-unf_ext
-+unicode-display_width 1.8.0 https://github.com/janlelis/unicode-display_width
++unicode-display_width 2.6.0 https://github.com/janlelis/unicode-display_width
 +uri 0.13.0 https://github.com/ruby/uri
 +webrick 1.9.1 https://github.com/ruby/webrick
-+github-pages 232 https://github.com/github/pages-gem

--- a/patches/ruby/bundled_gems.patch
+++ b/patches/ruby/bundled_gems.patch
@@ -1,15 +1,14 @@
 diff --git a/gems/bundled_gems b/gems/bundled_gems
-index ae0a1ac..96cc6a1 100644
+index aa96ab8..15daddb 100644
 --- a/gems/bundled_gems
 +++ b/gems/bundled_gems
-@@ -21,3 +21,103 @@ rbs             3.4.0   https://github.com/ruby/rbs
+@@ -21,3 +21,99 @@ rbs             3.4.0   https://github.com/ruby/rbs
  typeprof        0.21.9  https://github.com/ruby/typeprof
  debug           1.9.1   https://github.com/ruby/debug
  racc            1.7.3   https://github.com/ruby/racc
 +
 +activesupport 7.1.3.4 https://github.com/rails/rails/tree/v7.1.3.4/activesupport
 +addressable 2.8.7 https://github.com/sporkmonger/addressable
-+base64 0.3.0 https://github.com/ruby/base64
 +bigdecimal 3.2.2 https://github.com/ruby/bigdecimal
 +coffee-script 2.4.1 http://github.com/josh/ruby-coffee-script
 +coffee-script-source 1.12.2 http://coffeescript.org
@@ -17,9 +16,7 @@ index ae0a1ac..96cc6a1 100644
 +commonmarker 0.23.10 https://github.com/gjtorikian/commonmarker
 +concurrent-ruby 1.3.5 https://github.com/ruby-concurrency/concurrent-ruby
 +connection_pool 2.5.3 https://github.com/mperham/connection_pool
-+csv 3.3.5 https://github.com/ruby/csv
 +dnsruby 1.72.1 https://github.com/alexdalitz/dnsruby
-+drb 2.2.1 https://github.com/ruby/drb
 +em-websocket 0.5.3 http://github.com/igrigorik/em-websocket
 +ethon 0.16.0 https://github.com/typhoeus/ethon
 +eventmachine 1.2.7 http://rubyeventmachine.com
@@ -104,5 +101,4 @@ index ae0a1ac..96cc6a1 100644
 +unf 0.1.4 https://github.com/knu/ruby-unf
 +unf_ext 0.0.8.2 https://github.com/knu/ruby-unf_ext
 +unicode-display_width 1.8.0 https://github.com/janlelis/unicode-display_width
-+uri 0.13.0 https://github.com/ruby/uri
 +webrick 1.9.1 https://github.com/ruby/webrick

--- a/patches/ruby/bundled_gems.patch
+++ b/patches/ruby/bundled_gems.patch
@@ -1,15 +1,14 @@
 diff --git a/gems/bundled_gems b/gems/bundled_gems
-index aa96ab8..15daddb 100644
+index aa96ab8..2a2879c 100644
 --- a/gems/bundled_gems
 +++ b/gems/bundled_gems
-@@ -21,3 +21,99 @@ rbs             3.4.0   https://github.com/ruby/rbs
+@@ -21,3 +21,94 @@ rbs             3.4.0   https://github.com/ruby/rbs
  typeprof        0.21.9  https://github.com/ruby/typeprof
  debug           1.9.1   https://github.com/ruby/debug
  racc            1.7.3   https://github.com/ruby/racc
 +
 +activesupport 7.1.3.4 https://github.com/rails/rails/tree/v7.1.3.4/activesupport
 +addressable 2.8.7 https://github.com/sporkmonger/addressable
-+bigdecimal 3.2.2 https://github.com/ruby/bigdecimal
 +coffee-script 2.4.1 http://github.com/josh/ruby-coffee-script
 +coffee-script-source 1.12.2 http://coffeescript.org
 +colorator 1.1.0 https://github.com/octopress/colorator
@@ -82,11 +81,8 @@ index aa96ab8..15daddb 100644
 +octokit 4.25.1 https://github.com/octokit/octokit.rb
 +pathutil 0.16.2 http://github.com/envygeeks/pathutil
 +public_suffix 6.0.2 https://github.com/weppos/publicsuffix-ruby/tree/v5.1.1
-+racc 1.8.0 https://github.com/ruby/racc
-+rake 13.3.0 https://github.com/ruby/rake/tree/v13.2.1
 +rb-fsevent 0.11.2 https://github.com/thibaudgg/rb-fsevent
 +rb-inotify 0.11.1 https://github.com/guard/rb-inotify
-+rexml 3.4.1 https://github.com/ruby/rexml
 +rouge 3.30.0 https://github.com/rouge-ruby/rouge
 +rubyzip 2.3.2 https://github.com/rubyzip/rubyzip/tree/v2.3.2
 +safe_yaml 1.0.5 https://github.com/dtao/safe_yaml
@@ -94,7 +90,6 @@ index aa96ab8..15daddb 100644
 +sass-listen 4.0.0 https://github.com/sass/listen
 +sawyer 0.9.2 https://github.com/lostisland/sawyer
 +simpleidn 0.2.3 https://github.com/mmriis/simpleidn
-+strscan 3.1.5 https://github.com/ruby/strscan
 +terminal-table 1.8.0 https://github.com/tj/terminal-table
 +typhoeus 1.4.1 https://github.com/typhoeus/typhoeus
 +tzinfo 2.0.6 https://github.com/tzinfo/tzinfo/tree/v2.0.6

--- a/patches/ruby/bundled_gems.patch
+++ b/patches/ruby/bundled_gems.patch
@@ -76,7 +76,7 @@ index ae0a1ac..96cc6a1 100644
 +kramdown-parser-gfm 1.1.0 https://github.com/kramdown/parser-gfm
 +liquid 4.0.4 http://www.liquidmarkup.org
 +listen 3.9.0 https://github.com/guard/listen/tree/v3.9.0
-+mercenary 0.4.0 https://github.com/jekyll/mercenary
++mercenary 0.3.6 https://github.com/jekyll/mercenary
 +mini_portile2 2.8.7 https://github.com/flavorjones/mini_portile
 +minima 2.5.1 https://github.com/jekyll/minima
 +mutex_m 0.2.0 https://github.com/ruby/mutex_m
@@ -98,11 +98,11 @@ index ae0a1ac..96cc6a1 100644
 +sawyer 0.9.2 https://github.com/lostisland/sawyer
 +simpleidn 0.2.3 https://github.com/mmriis/simpleidn
 +strscan 3.1.5 https://github.com/ruby/strscan
-+terminal-table 3.0.2 https://github.com/tj/terminal-table
++terminal-table 1.8.0 https://github.com/tj/terminal-table
 +typhoeus 1.4.1 https://github.com/typhoeus/typhoeus
 +tzinfo 2.0.6 https://github.com/tzinfo/tzinfo/tree/v2.0.6
 +unf 0.1.4 https://github.com/knu/ruby-unf
 +unf_ext 0.0.8.2 https://github.com/knu/ruby-unf_ext
-+unicode-display_width 2.6.0 https://github.com/janlelis/unicode-display_width
++unicode-display_width 1.8.0 https://github.com/janlelis/unicode-display_width
 +uri 0.13.0 https://github.com/ruby/uri
 +webrick 1.9.1 https://github.com/ruby/webrick


### PR DESCRIPTION
This PR updates the list of default bundled gems to bump relevant versions and prune some to have a more concise yet still usable list of defaults.